### PR TITLE
Remove Unnecessary Fetch API Import

### DIFF
--- a/fetcher.js
+++ b/fetcher.js
@@ -1,6 +1,5 @@
 "use strict"
 
-const fetch = require("fetch");
 const Log = require("logger");
 
 const BASE_URL = "https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=USERNAME&api_key=API_KEY&limit=1&format=json";


### PR DESCRIPTION
This merge request removes the line `const fetch = require("fetch");` from the codebase. With the recent upgrade by the MagicMirror² repository to Node.js version 18+, the Fetch API is now natively supported, eliminating the need for an external fetch library import.

**Relevant Commit**:
- The MagicMirror² repository was upgraded to Node.js v18 in [this commit](https://github.com/MagicMirrorOrg/MagicMirror/commit/343e7de7bd295a69e68e4ee520552e0785a99e1c).
- Note that the MagicMirror² repository is currently using Node.js v20.